### PR TITLE
Vterm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # isend-mode [![MELPA](http://melpa.milkbox.net/packages/isend-mode-badge.svg)](http://melpa.milkbox.net/#/isend-mode)
 
-`isend-mode` is an Emacs extension allowing interaction with code interpreters in `ansi-term` or
-`term` buffers. Some language-specific modes (e.g. `python.el`) already provide similar features;
-`isend-mode` does the same in a language-agnostic way.
+`isend-mode` is an Emacs extension allowing interaction with code interpreters
+in `ansi-term`/`term` or `vterm` buffers. Some language-specific modes
+(e.g. `python.el`) already provide similar features; `isend-mode` does the same
+in a language-agnostic way.
 
 ![screencast](http://ffevotte.github.com/isend-mode.el/screencast/screencast.svg)
 
@@ -166,6 +167,7 @@ URL is:
 
 
 Many thanks go to the following contributors:
+- [Soumya Tripathy](https://github.com/Blade6570)
 - [James Porter](https://github.com/porterjamesj): empty lines handling;
 - [@albertstartup](https://github.com/albertstartup): handling newer version of
   iPython.


### PR DESCRIPTION
This extends #16.

Now that more destination buffer types are supported -- and, in particular, now that there are two supported terminal types: term/ansi-term & vterm -- this PR introduces a cleaner separation between the terminal-dependent implementation of phase-2 (during which contents from the source buffer are actually sent to the destination buffer).

This affects substantial parts of the code; I'm going to use it for a few weeks to test that everything works well before actually merging this. (Hopefully some day we'll have some form of tests and CI to be a bit more confident when introducing such changes)