### PR TITLE
skip line only when the entire line is empty

### DIFF
--- a/isend-mode.el
+++ b/isend-mode.el
@@ -374,6 +374,8 @@ The result is a cons cell of the form (beg . end)"
    ;; If the region is not active and `isend-skip-empty-lines' is non-nil,
    ;; move forward to the first non-empty line.
    (isend-skip-empty-lines
+    ;; in case the line isn't empty, we search from line beginning
+    (goto-char (line-beginning-position))
     (skip-chars-forward "[:space:]\n")
     (cons (point)
           (point)))


### PR DESCRIPTION
It is often the case that I finish writing one line of code and want to execute the current line as oppose to the next line, but this is not the default behavior in `isend` which will skip the `'\n'` and run the next line instead. This PR is a quick fix that works for me, so I want to send it here to see if you think this is a more sensible choice. 