### PR TITLE
Add support for eat destination buffers

### DIFF
--- a/isend-mode.el
+++ b/isend-mode.el
@@ -480,8 +480,8 @@ indentation."
   (vterm-send-return))
 
 (defun isend--send-dest-eat (contents)
-  (eat--send-input nil contents)
-  (eat--send-input nil "\n"))
+  (eat-send-string-as-yank eat--terminal contents)
+  (eat-send-string-as-yank eat--terminal "\n"))
 
 (provide 'isend-mode)
 

--- a/isend-mode.el
+++ b/isend-mode.el
@@ -447,6 +447,8 @@ indentation."
       (isend--send-dest-term contents))
      ((eq major-mode 'vterm-mode)
       (isend--send-dest-vterm contents))
+     ((eq major-mode 'eat-mode)
+      (isend--send-dest-eat contents))
      (t
       (isend--send-dest-default contents)))))
 
@@ -477,6 +479,9 @@ indentation."
   (vterm-send-string contents)
   (vterm-send-return))
 
+(defun isend--send-dest-eat (contents)
+  (eat--send-input nil contents)
+  (eat--send-input nil "\n"))
 
 (provide 'isend-mode)
 


### PR DESCRIPTION
The [eat terminal emulator](https://codeberg.org/akib/emacs-eat) is an emacs terminal emulator. It is written in pure elisp for portability, but is much faster than other emacs terminals written in elisp. `Vterm` is faster, but not by a large margin. 

This PR adds `isend-mode` support for eat terminal buffers. Tested with `eat` version 0.6 and emacs 30.0.50. 

`isend-mode` has some well-made infrastructure, this change was pretty simple to implement.